### PR TITLE
Refactor kdtree work

### DIFF
--- a/govhack/__init__.py
+++ b/govhack/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from flask import Flask, url_for, redirect
 
 from werkzeug.contrib.cache import SimpleCache
@@ -9,6 +11,11 @@ from . import models
 from flask.ext.cors import CORS
 
 app = Flask(__name__, instance_relative_config=True)
+
+#Initialise logging
+logger = logging.StreamHandler()
+
+app.logger.addHandler(logger)
 
 assets.register_assets(app)
 

--- a/govhack/geolocation_helpers.py
+++ b/govhack/geolocation_helpers.py
@@ -18,7 +18,7 @@ def get_kdtree(coordinates, use_cache=True):
 
 	kdtree_cached_file = StringIO.StringIO()
 
-	if kdtree_cached and use_cache:
+	if kdtree_cached_str and use_cache:
 		#Use cached version
 		kdtree_cached_file.write(kdtree_cached_str)
 		try:

--- a/govhack/geolocation_helpers.py
+++ b/govhack/geolocation_helpers.py
@@ -1,0 +1,37 @@
+import StringIO
+import sklearn.neighbors
+from sklearn.externals import joblib
+import numpy
+
+from . import cache
+
+
+def get_kdtree(coordinates, use_cache=True):
+	"""
+	Takes an iterable set of coordinate pairs, 
+	and creates a kdtree from them. May use cache.
+	"""
+
+	numpy_coords = numpy.array(coordinates)
+
+	kdtree_cached_str = cache.get("kdtree_cached")
+
+	kdtree_cached_file = StringIO.StringIO()
+
+	if kdtree_cached and use_cache:
+		#Use cached version
+		kdtree_cached_file.write(kdtree_cached_str)
+		try:
+			return joblib.load(kdtree_cached_file)
+		except:
+			#Reset the file and build a new model
+			kdtree_cached_file = StringIO.StringIO()
+
+	#Build new model
+	kdtree = sklearn.neighbors.KDTree(numpy_coords)
+	joblib.dump(kdtree, kdtree_cached_file)
+	cache.set("kdtree_cached", kdtree_cached_file.getvalue())
+
+	return kdtree
+
+

--- a/govhack/views.py
+++ b/govhack/views.py
@@ -289,7 +289,7 @@ def nearby_points():
     #Store list of dates
     peak_dates = []
 
-    #INDEX!!!
+    #Index all data so it can be retrieved by the kdtree query result
     for peak_tuple in all_peaks_as_tuples:
         peak_dict, peak_date = peak_tuple
         for key in peak_dict:
@@ -321,7 +321,7 @@ def nearby_points():
 
     _, (indices,) = query_result
 
-    #Marshal into results
+    #Marshall into results
     results = [{
         'date':peak_dates[indice], 
         'name': peak_names[indice], 
@@ -329,7 +329,7 @@ def nearby_points():
         'lon': peak_coords[indice][1],
     } for indice in indices]
 
-
+    #Return as JSON
     return json.dumps(results)
 
 @app.route('/db_test')

--- a/govhack/views.py
+++ b/govhack/views.py
@@ -6,9 +6,7 @@ import os
 import datetime
 import arrow
 from flask_swagger import swagger
-import sklearn.neighbors
-from sklearn.externals import joblib
-import numpy
+
 
 from sqlalchemy.sql.expression import func
 
@@ -16,6 +14,7 @@ from . import app
 from . import models
 from . import database
 from . import cache
+from . import geolocation_helpers
 
 @app.route('/')
 def index():
@@ -297,24 +296,7 @@ def nearby_points():
             peak_names.append(key)
             peak_dates.append(peak_date)
 
-    #Numpy the array so it's usable by KDTree
-    coords = numpy.array(peak_coords)
-
-    #Attempt to cache the tree / get tree out of cache
-    import StringIO
-    model_string = StringIO.StringIO()
-
-    kdtree_cached = cache.get("kdtree_cached")
-
-    if not kdtree_cached:
-        #Add positions to tree to build cached tree
-        kdtree = sklearn.neighbors.KDTree(coords)
-        joblib.dump(kdtree, model_string)
-        cache.set("kdtree_cached", model_string.getvalue())
-    else:
-        #Build tree from cache
-        model_string.write(kdtree_cached)
-        kdtree = joblib.load(model_string)
+    kdtree = geolocation_helpers.get_kdtree(peak_coords)
 
     #Query
     query_result = kdtree.query([[latitude, longitude]], k=5)


### PR DESCRIPTION
Refactors the kdtree logic out to a separate module, AND sets up the logging hooks for Flask correctly so Heroku can grab the logs directly without needing to use debug settings in Flask.
